### PR TITLE
add .gitignore entries for Cypress temporary assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ typings
 # System files
 .DS_Store
 Thumbs.db
+
+# Cypress temporary assets
+*/my-awesome-app/cypress/downloads
+*/my-awesome-app/cypress/screenshots
+*/my-awesome-app/cypress/videos


### PR DESCRIPTION
## Issue

Running Cypress tests results in temporary assets (videos) which should not be committed to `git`.

### Steps to reproduce

Execute

```bash
git status
```

and confirm `nothing to commit, working tree clean` is displayed, then execute

```bash
cd react/my-awesome-app
npm ci
npx cypress run --component
git status
```

Note that Untracked files: `cypress/videos/` are shown.

## Change

```text
# Cypress temporary assets
*/my-awesome-app/cypress/downloads
*/my-awesome-app/cypress/screenshots
*/my-awesome-app/cypress/videos
```

is added to [.gitignore](https://github.com/cypress-io/component-testing-quickstart-apps/blob/main/.gitignore)

## Verification

For each project:

```text
angular/my-awesome-app
react/my-awesome-app
svelte/my-awesome-app
vue/my-awesome-app
```

confirm that the following sequence does not generate any files which `git` shows as untracked:

```bash
npm ci
npx cypress run --component
git status
```
