### PR TITLE
ci: add GitHub Action CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        framework:
+          ["angular","react","svelte","vue"]
+
+    name: Test examples
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Cypress test
+        uses: cypress-io/github-action@v5
+        with:
+          component: true
+          working-directory: "${{ matrix.framework}}/my-awesome-app"


### PR DESCRIPTION
This PR adds the `.github/workflows/test.yml` workflow to test each of the quickstart apps using Cypress component testing:

1. [angular/my-awesome-app](https://github.com/cypress-io/component-testing-quickstart-apps/tree/main/angular/my-awesome-app)
1. [react/my-awesome-app](https://github.com/cypress-io/component-testing-quickstart-apps/tree/main/react/my-awesome-app)
1. [svelte/my-awesome-app](https://github.com/cypress-io/component-testing-quickstart-apps/tree/main/svelte/my-awesome-app)
1. [vue/my-awesome-app](https://github.com/cypress-io/component-testing-quickstart-apps/tree/main/vue/my-awesome-app)

This provides confidence of correctness when future changes are made to this repository.

The workflow makes use of [cypress-io/github-action](https://github.com/cypress-io/github-action).