### PR TITLE
ci(deps): update github action for node20 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,13 @@ jobs:
     name: Test examples
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 18
       - name: Cypress test
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           component: true
           working-directory: "${{ matrix.framework}}/my-awesome-app"


### PR DESCRIPTION
This PR updates JavaScript action versions in [.github/workflows/test.yml](https://github.com/cypress-io/component-testing-quickstart-apps/blob/main/.github/workflows/test.yml) to provide compatibility with `node20`.

GitHub has deprecated the use of actions based on `node16`. See  [GitHub Actions: Transitioning from Node 16 to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) dated Sep 22, 2023.
