### PR TITLE
ci(deps): update ci to node.js 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cypress test
         uses: cypress-io/github-action@v6
         with:


### PR DESCRIPTION
- Following on from PR https://github.com/cypress-io/component-testing-quickstart-apps/pull/16, the Angular example is now able to run under Node.js `20`. According to [Angular > Version compatibility](https://angular.io/guide/versions) Angular `16` (used before the PR) is supported on Node.js `^16.14.0 || ^18.10.0` and Angular `17` (currently used in the example) is supported on Node.js `^18.13.0 || ^20.9.0`

- This PR bumps the Node.js version used in [.github/workflows/test.yml](https://github.com/cypress-io/component-testing-quickstart-apps/blob/main/.github/workflows/test.yml) from `18` to `20`. Node.js `20` is the current active LTS (Long Term Support) version. See [Node.js release schedule](https://github.com/nodejs/release#release-schedule) for dates surrounding Node.js `18` and `20`.

- [actions/setup-node](https://github.com/actions/setup-node), also used in the above workflow, is bumped from `@v3` to `@v4`, thus moving from a `node16` to a `node20` environment for this JavaScript GitHub Action.