### PR TITLE
chore: update binaries to use published Cypress 14 binary

### DIFF
--- a/angular/my-awesome-app/package-lock.json
+++ b/angular/my-awesome-app/package-lock.json
@@ -25,7 +25,7 @@
         "@angular/cli": "^19.0.1",
         "@angular/compiler-cli": "^19.0.0",
         "@types/jasmine": "~5.1.0",
-        "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+        "cypress": "^14.0.0",
         "jasmine-core": "~5.4.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.2.0",

--- a/angular/my-awesome-app/package.json
+++ b/angular/my-awesome-app/package.json
@@ -27,7 +27,7 @@
     "@angular/cli": "^19.0.1",
     "@angular/compiler-cli": "^19.0.0",
     "@types/jasmine": "~5.1.0",
-    "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+    "cypress": "^14.0.0",
     "jasmine-core": "~5.4.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",

--- a/react/my-awesome-app/package-lock.json
+++ b/react/my-awesome-app/package-lock.json
@@ -15,7 +15,7 @@
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.4",
-        "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+        "cypress": "^14.0.0",
         "globals": "^15.12.0",
         "vite": "^6.0.1"
       }

--- a/react/my-awesome-app/package.json
+++ b/react/my-awesome-app/package.json
@@ -16,7 +16,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.4",
-    "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+    "cypress": "^14.0.0",
     "globals": "^15.12.0",
     "vite": "^6.0.1"
   }

--- a/svelte/my-awesome-app/package-lock.json
+++ b/svelte/my-awesome-app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
-        "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+        "cypress": "^14.0.0",
         "svelte": "^5.2.7",
         "vite": "^6.0.1"
       }

--- a/svelte/my-awesome-app/package.json
+++ b/svelte/my-awesome-app/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
-    "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+    "cypress": "^14.0.0",
     "svelte": "^5.2.7",
     "vite": "^6.0.1"
   }

--- a/vue/my-awesome-app/package-lock.json
+++ b/vue/my-awesome-app/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.2.1",
-        "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+        "cypress": "^14.0.0",
         "vite": "^6.0.1"
       }
     },

--- a/vue/my-awesome-app/package.json
+++ b/vue/my-awesome-app/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.1",
-    "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+    "cypress": "^14.0.0",
     "vite": "^6.0.1"
   }
 }


### PR DESCRIPTION
updates the 14 branch to use Cypress 14 published binary, which is currently at the dev tag