### PR TITLE
ci: update to Node.js 22 LTS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - name: Cypress test
         uses: cypress-io/github-action@v6
         with:


### PR DESCRIPTION
## Change

The [.github/workflows/test.yml](https://github.com/cypress-io/component-testing-quickstart-apps/blob/main/.github/workflows/test.yml) CI workflow is updated from Node.js `20` to `22`.

The [Node.js release schedule](https://github.com/nodejs/release#release-schedule) shows Node.js `22.x` moved to Active LTS status on Oct 29, 2024.

## Framework compatibility

The repo is now configured with the following framework versions, which are all compatible with Node.js `22.x`:

| Framework                                         | Version  | Node.js requirements                  |
| ------------------------------------------------- | -------- | ------------------------------------- |
| [Angular](https://angular.dev/reference/versions) | `19.0.3` | `^18.19.1 \|\| ^20.11.1 \|\| ^22.0.0` |
[React](https://react.dev/versions) | `19.0.0` | -
[Vite](https://vite.dev/guide/) | `6.0.3` | `^18.0.0 \|\| ^20.0.0 \|\| >=22.0.0`
[Svelte](https://svelte.dev/) | `5.7.0` | `>=18`
[Vue](https://vuejs.org/) | `3.5.13` | `>=18.3`
