### PR TITLE
fix: add TypeScript baseUrl for Angular example

### DIFF
--- a/angular/my-awesome-app/tsconfig.json
+++ b/angular/my-awesome-app/tsconfig.json
@@ -3,6 +3,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "strict": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
## Issue

The Angular test in [angular/my-awesome-app](https://github.com/cypress-io/component-testing-quickstart-apps/blob/main/angular/my-awesome-app) outputs the warning:

> Missing baseUrl in compilerOptions. tsconfig-paths will be skipped

See logs of [actions/workflows/test.yml](https://github.com/cypress-io/component-testing-quickstart-apps/actions/workflows/test.yml)

## Change

Add the following to [angular/my-awesome-app/tsconfig.json](https://github.com/cypress-io/component-testing-quickstart-apps/blob/main/angular/my-awesome-app/tsconfig.json)

```json
  "compilerOptions": {
    "baseUrl": "./",
...
},
```

according to the Angular documentation example https://angular.dev/reference/configs/angular-compiler-options.

## Verification

```shell
git clone https://github.com/cypress-io/component-testing-quickstart-apps
cd component-testing-quickstart-apps
cd angular/my-awesome-app
npm ci
npx cypress run --component
```

and confirm that the following warning no longer appears:

> Missing baseUrl in compilerOptions. tsconfig-paths will be skipped

Check also logs of [actions/workflows/test.yml](https://github.com/cypress-io/component-testing-quickstart-apps/actions/workflows/test.yml).

## Related

- https://github.com/cypress-io/cypress/issues/15724