### PR TITLE
fix: suppress webpack warnings in angular example

### DIFF
--- a/angular/my-awesome-app/cypress.config.ts
+++ b/angular/my-awesome-app/cypress.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     devServer: {
       framework: "angular",
       bundler: "webpack",
+      webpackConfig: { stats: "errors-only" }, // see issue https://github.com/cypress-io/cypress/issues/26456
     },
     specPattern: "**/*.cy.ts",
   },


### PR DESCRIPTION
## Issue

Running Cypress component tests in the following Angular project, results in multiple warnings:

- [angular](https://github.com/cypress-io/component-testing-quickstart-apps/tree/main/angular)

The warnings are similar to

> WARNING in /home/runner/work/component-testing-quickstart-apps/component-testing-quickstart-apps/angular/my-awesome-app/src/app/app.component.ts is part of the TypeScript compilation but it's unused.
> Add only entry points to the 'files' or 'include' properties in your tsconfig.

See [Action logs](https://github.com/cypress-io/component-testing-quickstart-apps/actions/workflows/test.yml?query=branch%3Amain).

## Assessment

- https://github.com/cypress-io/cypress/issues/26456 describes this issue for Angular projects with Cypress `12.9.0`.

- A community provided workaround in https://github.com/cypress-io/cypress/issues/26456#issuecomment-1751420036 suggests adding the following to the Angular / Webpack `cypress.config.ts` file:

    ```ts
    webpackConfig: { stats: "errors-only" }  // add this line to suppress webpack warnings
    ```

## Change

Add:

```ts
webpackConfig: { stats: "errors-only" }
```

to `cypress.config.ts` files in project:

- [angular](https://github.com/cypress-io/component-testing-quickstart-apps/tree/main/angular)
